### PR TITLE
docs: update sample/README to reflect generic library usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,5 @@ system-test/*key.json
 *.lock
 .DS_Store
 package-lock.json
-__pycache___
-_
+protos/google
+__pycache__

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -4,7 +4,7 @@
   "product_documentation": "https://cloud.google.com/container-registry/docs/container-analysis",
   "client_documentation": "https://googleapis.dev/nodejs/grafeas/latest/index.html",
   "issue_tracker": "",
-  "release_level": "ga",
+  "release_level": "beta",
   "language": "nodejs",
   "repo": "googleapis/nodejs-grafeas",
   "distribution_name": "@google-cloud/grafeas",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # [Grafeas: Node.js Client](https://github.com/googleapis/nodejs-grafeas)
 
-[![release level](https://img.shields.io/badge/release%20level-general%20availability%20%28GA%29-brightgreen.svg?style=flat)](https://cloud.google.com/terms/launch-stages)
+[![release level](https://img.shields.io/badge/release%20level-beta-yellow.svg?style=flat)](https://cloud.google.com/terms/launch-stages)
 [![npm version](https://img.shields.io/npm/v/@google-cloud/grafeas.svg)](https://www.npmjs.org/package/@google-cloud/grafeas)
 [![codecov](https://img.shields.io/codecov/c/github/googleapis/nodejs-grafeas/master.svg?style=flat)](https://codecov.io/gh/googleapis/nodejs-grafeas)
 
@@ -59,8 +59,13 @@ npm install @google-cloud/grafeas
   // const projectId = 'my-project';
 
   // instantiate the client.
+  const grpc = require('@grpc/grpc-js');
   const {GrafeasClient} = require('@google-cloud/grafeas');
-  const client = new GrafeasClient();
+  const client = new GrafeasClient({
+    sslCreds: grpc.credentials.createInsecure(), // or any other credentials object.
+    servicePath: '0.0.0.0', // overriding the service path
+    port: 8080, // and override port if needed
+  });
 
   // populate the request.
   const formattedName = client.projectPath(projectId);
@@ -95,12 +100,11 @@ also contains samples.
 This library follows [Semantic Versioning](http://semver.org/).
 
 
-This library is considered to be **General Availability (GA)**. This means it
-is stable; the code surface will not change in backwards-incompatible ways
-unless absolutely necessary (e.g. because of critical security issues) or with
-an extensive deprecation period. Issues and requests against **GA** libraries
-are addressed with the highest priority.
 
+This library is considered to be in **beta**. This means it is expected to be
+mostly stable while we work toward a general availability release; however,
+complete stability is not guaranteed. We will address issues and requests
+against beta libraries with a high priority.
 
 
 

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ npm install @google-cloud/grafeas
   const {GrafeasClient} = require('@google-cloud/grafeas');
   const client = new GrafeasClient({
     sslCreds: grpc.credentials.createInsecure(), // or any other credentials object.
-    servicePath: '0.0.0.0', // overriding the service path
-    port: 8080, // and override port if needed
+    servicePath: '0.0.0.0', // overriding the service path.
+    port: 8080, // overriding the port.
   });
 
   // populate the request.

--- a/samples/package.json
+++ b/samples/package.json
@@ -13,7 +13,8 @@
     "test": "mocha --timeout 600000 test/*.js"
   },
   "dependencies": {
-    "@google-cloud/grafeas": "^0.1.0"
+    "@google-cloud/grafeas": "^0.1.0",
+    "@grpc/grpc-js": "^0.4.1"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/samples/quickstart.js
+++ b/samples/quickstart.js
@@ -25,8 +25,13 @@ async function main(projectId) {
   // const projectId = 'my-project';
 
   // instantiate the client.
+  const grpc = require('@grpc/grpc-js');
   const {GrafeasClient} = require('@google-cloud/grafeas');
-  const client = new GrafeasClient();
+  const client = new GrafeasClient({
+    sslCreds: grpc.credentials.createInsecure(), // or any other credentials object.
+    servicePath: '0.0.0.0', // overriding the service path
+    port: 8080, // and override port if needed
+  });
 
   // populate the request.
   const formattedName = client.projectPath(projectId);

--- a/samples/quickstart.js
+++ b/samples/quickstart.js
@@ -29,8 +29,8 @@ async function main(projectId) {
   const {GrafeasClient} = require('@google-cloud/grafeas');
   const client = new GrafeasClient({
     sslCreds: grpc.credentials.createInsecure(), // or any other credentials object.
-    servicePath: '0.0.0.0', // overriding the service path
-    port: 8080, // and override port if needed
+    servicePath: '0.0.0.0', // overriding the service path.
+    port: 8080, // overriding the port.
   });
 
   // populate the request.

--- a/synth.metadata
+++ b/synth.metadata
@@ -1,5 +1,5 @@
 {
-  "updateTime": "2019-05-30T01:00:43.621638Z",
+  "updateTime": "2019-05-30T01:12:00.900491Z",
   "sources": [
     {
       "generator": {

--- a/synth.metadata
+++ b/synth.metadata
@@ -1,5 +1,5 @@
 {
-  "updateTime": "2019-05-24T23:41:49.443563Z",
+  "updateTime": "2019-05-30T01:00:43.621638Z",
   "sources": [
     {
       "generator": {
@@ -12,8 +12,8 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7ca19138ccebe219a67be2245200e821b3e32123",
-        "internalRef": "249916728"
+        "sha": "1079c999f0683196d857795ae6951ced9e15ce72",
+        "internalRef": "250569499"
       }
     },
     {


### PR DESCRIPTION
This PR updates the quiickstart.js and README.md to demonstrate how to negotiate a connection to a graefeas server other than googleapis.com.

## Testing Problems

I've unfortunately been unable to test that this implementation works, the testing server published to `grafeas/grafeas` runs against the `v1beta1` protos, which I believe are incompatible with the `v1` protos (which are what is published to `googleapis/googleapis`).

CC: @Katee any thoughts about how I could run a testing server to validate this client against?

## Updated Sample Tests

I'm not quite sure what a reasonable sample test would look like at this time; and am tempted to stick with just an integration test that connects to google cloud.

fixes #4 