### PR TITLE
fix(revert): revert exposing NoteKind enum; automate jsdoc fix

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,25 +13,23 @@
 // limitations under the License.
 
 /**
- * @namespace google
- */
-/**
- * @namespace google.cloud
- */
-/**
  * @namespace google.rpc
  */
 /**
  * @namespace google.protobuf
  */
 /**
+ * @namespace grafeas.v1
+ */
+
+/**
+ * @namespace google.cloud
+ */
+/**
  * @namespace google.cloud.grafeas
  */
 /**
  * @namespace google.cloud.grafeas.v1
- */
-/**
- * @namespace grafeas.v1
  */
 
 'use strict';
@@ -83,15 +81,6 @@ module.exports = gapic.v1;
  *   Reference to {@link v1.GrafeasClient}
  */
 module.exports.v1 = gapic.v1;
-module.exports.NoteKind = {
-  NOTE_KIND_UNSPECIFIED: 0,
-  VULNERABILITY: 1,
-  BUILD: 2,
-  IMAGE: 3,
-  PACKAGE: 4,
-  DEPLOYMENT: 5,
-  DISCOVERY: 6,
-  ATTESTATION: 7,
-};
+
 // Alias `module.exports` as `module.exports.default`, for future-proofing.
 module.exports.default = Object.assign({}, module.exports);

--- a/synth.metadata
+++ b/synth.metadata
@@ -1,5 +1,5 @@
 {
-  "updateTime": "2019-06-19T19:59:57.002930Z",
+  "updateTime": "2019-06-19T21:59:33.948571Z",
   "sources": [
     {
       "generator": {

--- a/synth.py
+++ b/synth.py
@@ -31,28 +31,25 @@ for version in versions:
  s.copy(library, excludes=[
    "README.md",
    "package.json",
-   "src/index.js",
    "src/v1/grafeas_client.js",
    "test/gapic-v1.js",
    "protos/google/*"
  ])
 
-# perform surgery inserting the Grafeas client.
 s.replace("src/index.js",
-r"""module.exports\.v1 = gapic\.v1;
-
-""",
-r"""module.exports.v1 = gapic.v1;
-module.exports.NoteKind = {
-  NOTE_KIND_UNSPECIFIED: 0,
-  VULNERABILITY: 1,
-  BUILD: 2,
-  IMAGE: 3,
-  PACKAGE: 4,
-  DEPLOYMENT: 5,
-  DISCOVERY: 6,
-  ATTESTATION: 7
-}
+r"""\/\*\*
+ \* @namespace google
+ \*/""",
+r"""
+/**
+ * @namespace google.rpc
+ */
+/**
+ * @namespace google.protobuf
+ */
+/**
+ * @namespace grafeas.v1
+ */
 """)
 
 # Copy common templates


### PR DESCRIPTION
* revert exposing NoteKind enum (in favor of addressing issue more broadly with documentation).
* fix jsdoc with regex, rather than not generating `src/index.js`.