### PR TITLE
test: increase system test timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,7 @@
   "main": "src/index.js",
   "files": [
     "protos",
-    "src",
-    "AUTHORS",
-    "COPYING"
+    "src"
   ],
   "keywords": [
     "google apis client",
@@ -48,7 +46,7 @@
     "predocs-test": "npm run docs",
     "docs-test": "linkinator docs",
     "samples-test": "c8 mocha samples/test/*.js",
-    "system-test": "c8 mocha --timeout=15000 system-test/*.js"
+    "system-test": "c8 mocha --timeout=150000 system-test/*.js"
   },
   "license": "Apache-2.0",
   "engines": {


### PR DESCRIPTION
System tests are currently failing on master because this takes a looooooooooooong time. 